### PR TITLE
Fix database to tmysql

### DIFF
--- a/lua/libk/server/sv_libk_database.lua
+++ b/lua/libk/server/sv_libk_database.lua
@@ -223,6 +223,7 @@ function LibK.getDatabaseConnection( config, name )
 		databaseObject.onConnected = function()
 			DB.Log( Format( "[LibK] Connected to %s(%s@%s:%s)", name, username, host, database_port ) )
 			DB.CONNECTED_TO_MYSQL = true
+			DB.MySQLDB = databaseObject
 			DB.cachedQueries = DB.cachedQueries or {}
 			if #DB.cachedQueries > 0 then
 				KLogf( 4, "[INFO] Connection to the database %s has been reestablished, running %i queued queries", name, #DB.cachedQueries )
@@ -246,7 +247,6 @@ function LibK.getDatabaseConnection( config, name )
 			hook.Call("LibK_DatabaseInitialized", nil, DB, name )		
 		end
 		databaseObject:connect()
-		DB.MySQLDB = databaseObject
 	end
 
 	function DB.SQLStr(str)


### PR DESCRIPTION
The DB.MySQLDB is read by DB.Query(v[1], v[2]) and is configured on final of script...
This change fix the error:
```
[ERROR] addons/libk/lua/libk/server/sv_libk_database.lua:257: attempt to index field 'MySQLDB' (a nil value)
  1. prepareForSQL - addons/libk/lua/libk/server/sv_libk_database.lua:257
   2. findAllDbByField - addons/libk/lua/libk/server/sv_libk_model.lua:239
    3. findByUid - addons/libk/lua/libk/server/sv_libk_model.lua:550
     4. fn - addons/libk/lua/libk/server/sv_libk_player.lua:3
      5. unknown - addons/ulib/lua/ulib/shared/hook.lua:110
```
and fix errors on line 108

I use tmysql with wrapper of mysqloo
https://github.com/blackawps/gm_tmysql4