### PR TITLE
fixed after gamemode calling name instead of addonTable.addonName

### DIFF
--- a/lua/libk/shared/sh_addonloader.lua
+++ b/lua/libk/shared/sh_addonloader.lua
@@ -122,7 +122,7 @@ local function doLoadAddon( addonTable )
 				loadAddon( addonTable )
 				onAddonInitialized( addonTable.addonName )
 			end )
-			KLog( 4, LibK.consoleHeader( 80, "*", "Addon ".. name .. " will be loaded after gamemode init" ) )
+			KLog( 4, LibK.consoleHeader( 80, "*", "Addon ".. addonTable.addonName .. " will be loaded after gamemode init" ) )
 		else
 			loadAddon( addonTable )
 			onAddonInitialized( addonTable.addonName )


### PR DESCRIPTION
This is pretty simple for a pull request, but gmod was throwing lua errors when trying to access the name variable, which was declared local in a different scope.