### PR TITLE
Fix NULL Entity error

### DIFF
--- a/lua/libk/server/sv_libk_player.lua
+++ b/lua/libk/server/sv_libk_player.lua
@@ -2,6 +2,11 @@
 function LibK.playerInitialSpawn( ply )
 	LibK.Player.findByUid( ply:UniqueID( ) )
 	:Then( function( dbPlayer )
+		if not IsValid( ply ) then
+			-- Player disconnected during join, do nothing
+			return
+		end
+
 		if dbPlayer then
 			dbPlayer.name = ply:Nick( ) 
 			return dbPlayer:save( )
@@ -16,7 +21,7 @@ function LibK.playerInitialSpawn( ply )
 	end )
 	:Then( function( dbPlayer )
 		if not IsValid( ply ) then
-			-- Player crashed during join, do nothing
+			-- Player disconnected during join, do nothing
 			return
 		end
 


### PR DESCRIPTION
This should "fix" the following error:
`libk/lua/libk/server/sv_libk_player.lua:6: Tried to use a NULL entity!`

This error comes when the player somehow leaves the server shortly after joining it.