### PR TITLE
Added working mysqloo 9.7.+ support

### DIFF
--- a/lua/libk/3rdparty/mysqloolib.lua
+++ b/lua/libk/3rdparty/mysqloolib.lua
@@ -82,9 +82,19 @@ mysqloolib = {}
 ]==]
 
 local db = {}
-local baseMeta = FindMetaTable("MySQLOO Database") or {} -- this ensures backwards compatibility to <=9.6
+local baseMetaInitialized = false
+local baseMeta = {}
+local function getBaseMeta()
+	if (!baseMetaInitialized) then
+		-- this ensures backwards compatibility to <=9.6
+		baseMeta = FindMetaTable("MySQLOO Database") or {}
+		baseMetaInitialized = true
+	end
+	return baseMeta
+end
+
 local dbMetatable = {__index = function(tbl, key)
-	return (db[key] or baseMeta[key])
+	return db[key] or getBaseMeta()[key]
 end}
 
 --This converts an already existing database instance to be able to make use
@@ -162,9 +172,19 @@ function db:PrepareQuery(str, values, callback, ...)
 end
 
 local transaction = {}
-local baseTransactionMeta = FindMetaTable("MySQLOO Transaction") or {} -- this ensures backwards compatibility to <=9.6
+local baseTransactionMetaInitialized = false
+local baseTransactionMeta = {}
+local function getBaseTransactionMeta()
+	if (!baseTransactionMetaInitialized) then
+		-- this ensures backwards compatibility to <=9.6
+		baseTransactionMeta = FindMetaTable("MySQLOO Transaction") or {}
+		baseTransactionMetaInitialized = true
+	end
+	return baseTransactionMeta
+end
+
 local transactionMT = {__index = function(tbl, key)
-	return (transaction[key] or baseTransactionMeta[key])
+	return transaction[key] or getBaseTransactionMeta()[key]
 end}
 
 function transaction:Prepare(str, values)
@@ -174,7 +194,7 @@ function transaction:Prepare(str, values)
 	self:addQuery(preparedQuery)
 	return preparedQuery
 end
-																	
+
 function transaction:Query(str)
 	local query = self._db:query(str)
 	self:addQuery(query)

--- a/lua/libk/server/sv_libk_database.lua
+++ b/lua/libk/server/sv_libk_database.lua
@@ -10,7 +10,7 @@ function LibK.SetBlocking( bShouldBlock )
 	LibK.databaseShouldBlock = bShouldBlock
 end
 
-hook.Add( "LibK_DatabaseConnectionFailed", function ( DB, name, msg )
+hook.Add( "LibK_DatabaseConnectionFailed", "LibKHook", function ( DB, name, msg )
 	DB.ConnectionPromise:Reject( tostring( msg ) )
 end )
 


### PR DESCRIPTION
My last PR (#39) did unfortunately not work with myslqoo 9.7 because mysqloo is required after the mysqloolib is loaded, which causes the metatables to not exist at the point the script is loaded.
This PR fixes this issue by lazy loading the metatables to where they are only attempted to be loaded after mysqloo was already required.
I tested this using mysqloo 9.6, 9.7 and without any mysqloo, and everything works as expected now.

I also fixed a hook name missing in sv_libk_database.lua which threw an error when I tried to load libk (maybe it worked for you because you are using a modified hook library?). Please check if this is correct though.